### PR TITLE
add name attribute to input

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,6 +45,8 @@ This package will add a svelte component that may or may not receive a configura
 | score      |   `float`    |    false    |     0.0      |
 | showScore  |   `bool`     |    false    |     true     |
 | scoreFormat|   `function` |    false    |    precent   |
+| name       |   `String`   |    false    |     ""     | 
+
 
 In addition, we have two other nested attributes that specify distinct settings.
 
@@ -80,6 +82,7 @@ const config = {
   score: 0.0,
   showScore: true,
   scoreFormat: function(){ return `(${this.score.toFixed(0)}/${this.countStars})` },
+  name: "",
   starConfig: {
     size: 30,
     fillColor: '#F9ED4F',

--- a/src/Stars.svelte
+++ b/src/Stars.svelte
@@ -1,11 +1,12 @@
 <script>
   import Star from './components/Star.svelte';
   export let config = {
-		readOnly: false,
+    readOnly: false,
     countStars: 5,
     range: {min: 0, max: 5, step: 0.001},
     score: 0.0,
     showScore: true,
+    name: "",
     starConfig: {
       size: 30,
       fillColor: '#F9ED4F',
@@ -29,7 +30,7 @@
         {/if}
       {/each}
     </div>
-    <input class="slider" disabled={config.readOnly} type="range" min={config.range.min} max={config.range.max} step="{config.range.step}" bind:value={config.score} on:change >
+    <input name={config.name} class="slider" disabled={config.readOnly} type="range" min={config.range.min} max={config.range.max} step="{config.range.step}" bind:value={config.score} on:change >
   </div>
   {#if config.showScore}
     <span class="show-score" style="font-size: {config.starConfig.size/2}px;">


### PR DESCRIPTION
I was tinkering with it a bit more and having the name attribute on the input for using it inside a `<form>` for sveltekit form actions seems pretty useful.

https://stackoverflow.com/questions/12543848/does-form-data-still-transfer-if-the-input-tag-has-no-name

Otherwise it will not be in the data sent to the server