### PR TITLE
Issue: #14 -  Added ternary to change readOnly behavior, added on:click event

### DIFF
--- a/src/Stars.svelte
+++ b/src/Stars.svelte
@@ -31,7 +31,15 @@
         {/if}
       {/each}
     </div>
-    <input name={config.name} class="slider" disabled={config.readOnly} type="range" min={config.range.min} max={config.range.max} step="{config.range.step}" bind:value={config.score} on:change >
+    <input  name={config.name} 
+            class="slider" 
+            type="range" 
+            min={config.readOnly ? config.score : config.range.min} 
+            max={config.readOnly ? config.score : config.range.max} 
+            step="{config.range.step}" bind:value={config.score} 
+            on:change 
+            on:click 
+    >
   </div>
   {#if config.showScore}
     <span class="show-score" style="font-size: {config.starConfig.size/2}px;">


### PR DESCRIPTION
This PR aims to adjust the input responsible for controlling the "rating" value, given that when the `readOnly = true` value was assigned, it would be disabled, preventing click events.

A ternary operator was created to set the minimum and maximum values of the input, where in the case of `readOnly`, the values will be the same as the defined score, preventing user changes.