### PR TITLE
missing exports condition for svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
     "svelte": "dist/index.js"
-  },
+    }
+  }
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+    "svelte": "dist/index.js"
+  },
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w"


### PR DESCRIPTION
Prevents the Vite warning "missing svelte export condition" according to [https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition)

Fixes #16 